### PR TITLE
refactor: remove hardcoded paths and integrate project configuration for panel conversion

### DIFF
--- a/src/converter.ts
+++ b/src/converter.ts
@@ -15,8 +15,11 @@ import * as os from 'os';
 import { pnlToXml, xmlToPnl } from '@winccoa-tools-pack/npm-winccoa-ui-pnl-xml';
 import { ExtensionOutputChannel } from './extensionOutput';
 import { getSelectedProject } from './otherExtensions';
-import { ProjEnvProject, ProjEnvProjectFileSysStruct, getProjectByProjectPath } from '@winccoa-tools-pack/npm-winccoa-core';
-
+import {
+    ProjEnvProject,
+    ProjEnvProjectFileSysStruct,
+    getProjectByProjectPath,
+} from '@winccoa-tools-pack/npm-winccoa-core';
 
 /** Result of a conversion operation */
 export interface ConversionResult {
@@ -41,9 +44,7 @@ export async function isEncryptedPanel(filePath: string): Promise<boolean> {
     }
 }
 
-
-async function getWinccoaProject(oaPanelPath : string): Promise<ProjEnvProject | undefined> {
-
+async function getWinccoaProject(oaPanelPath: string): Promise<ProjEnvProject | undefined> {
     let currentProject: ProjEnvProject | undefined = await getProjectByProjectPath(oaPanelPath);
 
     if (currentProject) {
@@ -51,7 +52,6 @@ async function getWinccoaProject(oaPanelPath : string): Promise<ProjEnvProject |
     }
 
     currentProject = (await getSelectedProject()) ?? undefined;
-
 
     if (!currentProject) {
         vscode.window.showWarningMessage(
@@ -111,7 +111,10 @@ export async function convertPnlToXml(
     // WCCOAui requires panel paths relative to project panels directory
     // Create a temp subfolder inside panels dir, copy file there, convert
     const tempSubDir = `_temp_convert_${Date.now()}`;
-    const tempPanelsPath = path.join(oaProj.getDir(ProjEnvProjectFileSysStruct.PANELS_REL_PATH), tempSubDir);
+    const tempPanelsPath = path.join(
+        oaProj.getDir(ProjEnvProjectFileSysStruct.PANELS_REL_PATH),
+        tempSubDir,
+    );
 
     // Ensure temp directory exists
     await fs.promises.mkdir(tempPanelsPath, { recursive: true });
@@ -203,7 +206,10 @@ export async function convertXmlToPnl(
     // WCCOAui requires panel paths relative to project panels directory
     // Create a temp subfolder inside panels dir, copy file there, convert
     const tempSubDir = `_temp_convert_${Date.now()}`;
-    const tempPanelsPath = path.join(oaProj.getDir(ProjEnvProjectFileSysStruct.PANELS_REL_PATH), tempSubDir);
+    const tempPanelsPath = path.join(
+        oaProj.getDir(ProjEnvProjectFileSysStruct.PANELS_REL_PATH),
+        tempSubDir,
+    );
 
     // Ensure temp directory exists
     await fs.promises.mkdir(tempPanelsPath, { recursive: true });

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -15,16 +15,8 @@ import * as os from 'os';
 import { pnlToXml, xmlToPnl } from '@winccoa-tools-pack/npm-winccoa-ui-pnl-xml';
 import { ExtensionOutputChannel } from './extensionOutput';
 import { getSelectedProject } from './otherExtensions';
+import { ProjEnvProject, ProjEnvProjectFileSysStruct, getProjectByProjectPath } from '@winccoa-tools-pack/npm-winccoa-core';
 
-// TODO: Get config path from winccoa-project-admin extension when available
-// Hardcoded for playground/testing
-const TEMP_CONFIG_PATH =
-    'C:\\ws\\ETM\\WinCCOA\\support\\3.20\\Test\\CtrlTF\\WinCC_OA_Test\\Projects\\TfCustomized\\config\\config';
-
-// TODO: Get panels directory from winccoa-project-admin extension when available
-// Hardcoded for playground/testing - panel paths must be relative to this directory
-const TEMP_PANELS_DIR =
-    'C:\\ws\\ETM\\WinCCOA\\support\\3.20\\Test\\CtrlTF\\WinCC_OA_Test\\Projects\\TfCustomized\\panels';
 
 /** Result of a conversion operation */
 export interface ConversionResult {
@@ -49,24 +41,40 @@ export async function isEncryptedPanel(filePath: string): Promise<boolean> {
     }
 }
 
-/**
- * Gets the WinCC OA version to use for conversion.
- * TODO: Integrate with RichardJanisch.winccoa-project-admin extension to pick version dynamically
- */
-function getWinccoaVersion(): string | undefined {
-    const currentProject = getSelectedProject();
+
+async function getWinccoaProject(oaPanelPath : string): Promise<ProjEnvProject | undefined> {
+
+    let currentProject: ProjEnvProject | undefined = await getProjectByProjectPath(oaPanelPath);
+
+    if (currentProject) {
+        return currentProject;
+    }
+
+    currentProject = (await getSelectedProject()) ?? undefined;
+
 
     if (!currentProject) {
+        vscode.window.showWarningMessage(
+            `No WinCC OA project selected; cannot determine WinCC OA version for conversion for given panel ${oaPanelPath}.\nPlease select a runnable project and try again.`,
+        );
         return undefined;
     }
 
     if (!currentProject.getVersion()) {
         vscode.window.showWarningMessage(
-            `Unable to determine WinCC OA version from the selected project ${currentProject.getId()}.`,
+            `Selected project "${currentProject.getName()}" does not have a version; cannot determine WinCC OA version for conversion for given panel ${oaPanelPath}.\nPlease select a runnable project with a version and try again.`,
         );
+        return undefined;
     }
 
-    return currentProject.getVersion();
+    if (!currentProject.getConfigPath()) {
+        vscode.window.showWarningMessage(
+            `Selected project "${currentProject.getName()}" does not have a config file; cannot determine WinCC OA version for conversion for given panel ${oaPanelPath}.\nPlease select a runnable project with a config file and try again.`,
+        );
+        return undefined;
+    }
+
+    return currentProject;
 }
 
 /**
@@ -87,20 +95,23 @@ export async function convertPnlToXml(
         return { success: false, error: 'Encrypted panel; content not viewable.' };
     }
 
-    const version = getWinccoaVersion();
-    if (!version) {
+    const oaProj = await getWinccoaProject(pnlPath);
+
+    if (!oaProj) {
         return {
             success: false,
-            error: 'No WinCC OA project selected; cannot determine WinCC OA version for conversion.',
+            error: 'No WinCC OA project selected; cannot determine WinCC OA project for conversion.',
         };
     }
+
+    const version = oaProj.getVersion();
 
     const baseName = path.basename(pnlPath);
 
     // WCCOAui requires panel paths relative to project panels directory
     // Create a temp subfolder inside panels dir, copy file there, convert
     const tempSubDir = `_temp_convert_${Date.now()}`;
-    const tempPanelsPath = path.join(TEMP_PANELS_DIR, tempSubDir);
+    const tempPanelsPath = path.join(oaProj.getDir(ProjEnvProjectFileSysStruct.PANELS_REL_PATH), tempSubDir);
 
     // Ensure temp directory exists
     await fs.promises.mkdir(tempPanelsPath, { recursive: true });
@@ -119,9 +130,9 @@ export async function convertPnlToXml(
         );
 
         const result = await pnlToXml({
-            version,
+            version: version || 'unknown',
             inputPath: relativePath,
-            configPath: TEMP_CONFIG_PATH, // TODO: Get from winccoa-project-admin
+            configPath: oaProj.getConfigPath() || '',
             overwrite: true,
         });
 
@@ -178,11 +189,12 @@ export async function convertXmlToPnl(
     xmlPath: string,
     outputDir?: string,
 ): Promise<ConversionResult> {
-    const version = getWinccoaVersion();
-    if (!version) {
+    const oaProj = await getWinccoaProject(xmlPath);
+
+    if (!oaProj) {
         return {
             success: false,
-            error: 'No WinCC OA project selected; cannot determine WinCC OA version for conversion.',
+            error: 'No WinCC OA project selected; cannot determine WinCC OA project for conversion.',
         };
     }
 
@@ -191,7 +203,7 @@ export async function convertXmlToPnl(
     // WCCOAui requires panel paths relative to project panels directory
     // Create a temp subfolder inside panels dir, copy file there, convert
     const tempSubDir = `_temp_convert_${Date.now()}`;
-    const tempPanelsPath = path.join(TEMP_PANELS_DIR, tempSubDir);
+    const tempPanelsPath = path.join(oaProj.getDir(ProjEnvProjectFileSysStruct.PANELS_REL_PATH), tempSubDir);
 
     // Ensure temp directory exists
     await fs.promises.mkdir(tempPanelsPath, { recursive: true });
@@ -206,13 +218,13 @@ export async function convertXmlToPnl(
     try {
         ExtensionOutputChannel.debug(
             'Converter',
-            `Converting XML to PNL: ${relativePath} (version: ${version})`,
+            `Converting XML to PNL: ${relativePath} (version: ${oaProj.getVersion()})`,
         );
 
         const result = await xmlToPnl({
-            version,
+            version: oaProj.getVersion() || 'unknown',
             inputPath: relativePath,
-            configPath: TEMP_CONFIG_PATH, // TODO: Get from winccoa-project-admin
+            configPath: oaProj.getConfigPath() || '',
             overwrite: true,
         });
 


### PR DESCRIPTION
## Summary

Removes hardcoded local machine paths and replaces them with dynamic project configuration resolved at runtime via @winccoa-tools-pack/npm-winccoa-core.

## Changes

- **Removed** two hardcoded constants (TEMP_CONFIG_PATH, TEMP_PANELS_DIR) that referenced a developer's local file system paths.
- **Replaced** the synchronous getWinccoaVersion() helper with a new async getWinccoaProject(oaPanelPath) function that:
  - First tries to resolve the WinCC OA project from the panel file path using getProjectByProjectPath.
  - Falls back to the user-selected project via getSelectedProject().
  - Validates that the resolved project has both a version and a config file path, showing descriptive warning messages when either is missing.
- **Updated** convertPnlToXml and convertXmlToPnl to use the resolved ProjEnvProject object for:
  - The WinCC OA version (oaProj.getVersion()).
  - The config file path (oaProj.getConfigPath()).
  - The panels directory (oaProj.getDir(ProjEnvProjectFileSysStruct.PANELS_REL_PATH)).
- **Added** imports: ProjEnvProject, ProjEnvProjectFileSysStruct, getProjectByProjectPath from @winccoa-tools-pack/npm-winccoa-core.
- **Improved** user-facing warning messages to include the panel path and actionable guidance.

## Why

The hardcoded paths made the extension unusable on any machine other than the original developer's workstation. This change makes panel conversion work correctly for any WinCC OA project configured in the extension.

thx to @mw-enet to report the issue
