### PR TITLE
feat: enhance panel file support by adding XML handling and refactoring project retrieval logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "onStartupFinished",
     "onLanguage:xml",
     "workspaceContains:**/*.pnl",
+    "workspaceContains:**/panels/*.xml",
+    "workspaceContains:**/panels/**/*.xml",
     "onLanguageModelTool:winccoaPanelViewer_listLoadedPanels",
     "onLanguageModelTool:winccoaPanelViewer_getPanelModel",
     "onLanguageModelTool:winccoaPanelViewer_openPanelInViewer",
@@ -81,7 +83,7 @@
           "properties": {
             "filePath": {
               "type": "string",
-              "description": "Absolute file system path of the panel (.pnl) to retrieve. If omitted, uses the currently opened panel (or the only loaded panel)."
+              "description": "Absolute file system path of the panel (.pnl or .xml) to retrieve. If omitted, uses the currently opened panel (or the only loaded panel)."
             },
             "includeScripts": {
               "type": "boolean",
@@ -431,7 +433,7 @@
       "explorer/context": [
         {
           "command": "winccoaPanelViewer.openPanel",
-          "when": "resourceExtname == .pnl",
+          "when": "resourceExtname == .pnl || resourceExtname == .xml",
           "group": "winccoa@1"
         },
         {
@@ -456,17 +458,17 @@
         },
         {
           "command": "winccoaPanelViewer.previewPanel",
-          "when": "resourceExtname == .pnl",
+          "when": "resourceExtname == .pnl || resourceExtname == .xml",
           "group": "winccoa@4"
         },
         {
           "command": "winccoaPanelViewer.previewPanelWithOptions",
-          "when": "resourceExtname == .pnl",
+          "when": "resourceExtname == .pnl || resourceExtname == .xml",
           "group": "winccoa@4"
         },
         {
           "command": "winccoaPanelViewer.checkPanelSyntax",
-          "when": "resourceExtname == .pnl",
+          "when": "resourceExtname == .pnl || resourceExtname == .xml",
           "group": "winccoa@5"
         }
       ],

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -26,6 +26,7 @@ import { getSelectedProject } from './otherExtensions';
 import { CORE_EXTENSION_ID } from './const';
 import { ProjEnvProjectFileSysStruct } from '@winccoa-tools-pack/npm-winccoa-core';
 import { checkPanels } from '@winccoa-tools-pack/npm-winccoa-syntax-check';
+import { getWinccoaProject } from './utils';
 
 /** Singleton tree provider instance */
 let treeProvider: PanelTreeProvider | undefined;
@@ -245,7 +246,7 @@ async function checkPanelSyntaxCommand(uri?: vscode.Uri): Promise<void> {
                 canSelectFiles: true,
                 canSelectFolders: false,
                 canSelectMany: false,
-                filters: { 'WinCC OA Panels': ['pnl'] },
+                filters: { 'WinCC OA Panels': ['pnl', 'xml'] },
                 title: 'Select Panel File to Check Syntax',
             });
             if (!picked || picked.length === 0) {
@@ -256,11 +257,8 @@ async function checkPanelSyntaxCommand(uri?: vscode.Uri): Promise<void> {
 
         const normalizedPath = filePath.replace(/\\/g, path.sep);
 
-        const currentProject = getSelectedProject();
+        const currentProject = await getWinccoaProject(normalizedPath);
         if (!currentProject) {
-            void vscode.window.showErrorMessage(
-                'No WinCC OA project selected. Select a project in WinCC OA Project Admin first.',
-            );
             return;
         }
 
@@ -1421,7 +1419,7 @@ function registerLanguageModelTools(context: vscode.ExtensionContext): void {
 
                         const normalizedPath = filePath.replace(/\\/g, path.sep);
 
-                        const currentProject = getSelectedProject();
+                        const currentProject = await getWinccoaProject(normalizedPath);
                         if (!currentProject) {
                             return new vscode.LanguageModelToolResult([
                                 new vscode.LanguageModelTextPart(
@@ -1657,7 +1655,7 @@ async function openPanelCommand(uri?: vscode.Uri): Promise<void> {
             canSelectFiles: true,
             canSelectFolders: false,
             canSelectMany: false,
-            filters: { 'WinCC OA Panels': ['pnl'] },
+            filters: { 'WinCC OA Panels': ['pnl', 'xml'] },
             title: 'Select Panel File',
         });
         if (!uris || uris.length === 0) return;
@@ -2036,7 +2034,7 @@ async function _previewPanel(uri?: vscode.Uri, extraUiViewerOptions?: string[]):
         return;
     }
 
-    const currentProject = getSelectedProject();
+    const currentProject = await getWinccoaProject(filePath);
 
     if (!currentProject) {
         return;

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -14,12 +14,8 @@ import * as path from 'path';
 import * as os from 'os';
 import { pnlToXml, xmlToPnl } from '@winccoa-tools-pack/npm-winccoa-ui-pnl-xml';
 import { ExtensionOutputChannel } from './extensionOutput';
-import { getSelectedProject } from './otherExtensions';
-import {
-    ProjEnvProject,
-    ProjEnvProjectFileSysStruct,
-    getProjectByProjectPath,
-} from '@winccoa-tools-pack/npm-winccoa-core';
+import { getWinccoaProject } from './utils';
+import { ProjEnvProjectFileSysStruct } from '@winccoa-tools-pack/npm-winccoa-core';
 
 /** Result of a conversion operation */
 export interface ConversionResult {
@@ -42,39 +38,6 @@ export async function isEncryptedPanel(filePath: string): Promise<boolean> {
     } catch {
         return false;
     }
-}
-
-async function getWinccoaProject(oaPanelPath: string): Promise<ProjEnvProject | undefined> {
-    let currentProject: ProjEnvProject | undefined = await getProjectByProjectPath(oaPanelPath);
-
-    if (currentProject) {
-        return currentProject;
-    }
-
-    currentProject = (await getSelectedProject()) ?? undefined;
-
-    if (!currentProject) {
-        vscode.window.showWarningMessage(
-            `No WinCC OA project selected; cannot determine WinCC OA version for conversion for given panel ${oaPanelPath}.\nPlease select a runnable project and try again.`,
-        );
-        return undefined;
-    }
-
-    if (!currentProject.getVersion()) {
-        vscode.window.showWarningMessage(
-            `Selected project "${currentProject.getName()}" does not have a version; cannot determine WinCC OA version for conversion for given panel ${oaPanelPath}.\nPlease select a runnable project with a version and try again.`,
-        );
-        return undefined;
-    }
-
-    if (!currentProject.getConfigPath()) {
-        vscode.window.showWarningMessage(
-            `Selected project "${currentProject.getName()}" does not have a config file; cannot determine WinCC OA version for conversion for given panel ${oaPanelPath}.\nPlease select a runnable project with a config file and try again.`,
-        );
-        return undefined;
-    }
-
-    return currentProject;
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,36 @@
+import * as vscode from 'vscode';
+import { getSelectedProject } from './otherExtensions';
+import { ProjEnvProject, getProjectByProjectPath } from '@winccoa-tools-pack/npm-winccoa-core';
+
+export async function getWinccoaProject(oaPanelPath: string): Promise<ProjEnvProject | undefined> {
+    let currentProject: ProjEnvProject | undefined = await getProjectByProjectPath(oaPanelPath);
+
+    if (currentProject) {
+        return currentProject;
+    }
+
+    currentProject = (await getSelectedProject()) ?? undefined;
+
+    if (!currentProject) {
+        vscode.window.showWarningMessage(
+            `No WinCC OA project selected; cannot determine WinCC OA version for conversion for given panel ${oaPanelPath}.\nPlease select a runnable project and try again.`,
+        );
+        return undefined;
+    }
+
+    if (!currentProject.getVersion()) {
+        vscode.window.showWarningMessage(
+            `Selected project "${currentProject.getName()}" does not have a version; cannot determine WinCC OA version for conversion for given panel ${oaPanelPath}.\nPlease select a runnable project with a version and try again.`,
+        );
+        return undefined;
+    }
+
+    if (!currentProject.getConfigPath()) {
+        vscode.window.showWarningMessage(
+            `Selected project "${currentProject.getName()}" does not have a config file; cannot determine WinCC OA version for conversion for given panel ${oaPanelPath}.\nPlease select a runnable project with a config file and try again.`,
+        );
+        return undefined;
+    }
+
+    return currentProject;
+}


### PR DESCRIPTION
## Summary

Extends the extension to treat XML panel files (.xml inside a panels/ directory) as first-class citizens alongside .pnl files, and extracts the shared getWinccoaProject helper into a dedicated utils.ts module so it can be reused across the codebase.

## Changes

### src/utils.ts (new file)
- Extracts the getWinccoaProject(oaPanelPath) helper that was previously inlined in converter.ts into a shared utility module so it can be consumed by both converter.ts and commands.ts.

### src/converter.ts
- Removes the inlined getWinccoaProject function and its direct imports of getSelectedProject, ProjEnvProject, and getProjectByProjectPath.
- Imports getWinccoaProject from the new ./utils module instead.

### src/commands.ts
- Imports getWinccoaProject from ./utils.
- Replaces bare getSelectedProject() calls with wait getWinccoaProject(normalizedPath / filePath) in:
  - checkPanelSyntaxCommand
  - _previewPanel
  - The winccoaPanelViewer_checkPanelSyntax language model tool handler
- Updates file-picker ilters to include xml alongside pnl in openPanelCommand and checkPanelSyntaxCommand.

### package.json
- Adds two new activation events so the extension activates when the workspace contains XML panel files:
  - workspaceContains:**/panels/*.xml
  - workspaceContains:**/panels/**/*.xml
- Extends the Explorer context menu when conditions for openPanel, previewPanel, previewPanelWithOptions, and checkPanelSyntax to also fire on .xml files (
esourceExtname == .xml).
- Updates the ilePath property description of the winccoaPanelViewer_getPanelModel LM tool to mention .xml in addition to .pnl.

## Why

WinCC OA panels can exist in their XML representation (converted from .pnl). Previously the extension only recognised .pnl files in its context menus, file pickers, and activation events, forcing users to work around the limitation. With this change, all major entry points — context menus, command palette file pickers, the panel viewer, syntax checker, and the Copilot LM tool — handle both formats transparently.

thx to @mw-enet3 to report this issue

## Testing

<img width="412" height="483" alt="image" src="https://github.com/user-attachments/assets/9fc9aa26-7b17-4830-845a-ae4fb9f62903" />
