### PR TITLE
chore: upmerge main to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.5] - 2026-03-26
+
+### Added
+
+- enhance panel file support by adding XML handling and refactoring project retrieval logic (#50)
+
 ## [0.2.4] - 2026-03-25
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "winccoa-ui-panel-viewer",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "winccoa-ui-panel-viewer",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
         "@winccoa-tools-pack/npm-winccoa-core": "0.2.6",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "WinCC OA UI Panel Viewer",
   "description": "Read-only viewer for WinCC OA .pnl panel files with structure tree, properties, scripts, and preview launcher.",
   "publisher": "winccoa-tools-pack",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "author": "winccoa-tools-pack",
   "license": "MIT",
   "icon": "resources/icon.png",


### PR DESCRIPTION
This PR keeps `develop` up to date with `main` by merging `main` into a dedicated upmerge branch.

No merge conflicts detected — auto-merge enabled.